### PR TITLE
Fix missing libgomp.so.1 in game_predictor Docker image

### DIFF
--- a/game_predictor/Dockerfile
+++ b/game_predictor/Dockerfile
@@ -1,5 +1,6 @@
 FROM python:3.12-slim
 WORKDIR /app
+RUN apt-get update && apt-get install -y --no-install-recommends libgomp1 && rm -rf /var/lib/apt/lists/*
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . .


### PR DESCRIPTION
Install libgomp1 system package before pip dependencies so LightGBM
can load its shared library at runtime.

https://claude.ai/code/session_016EheqTXKSmZehYMh5ieKMo