### PR TITLE
Fix missing timezone data in webapi Alpine image

### DIFF
--- a/WebApi/Dockerfile
+++ b/WebApi/Dockerfile
@@ -12,7 +12,7 @@ COPY Entities/ Entities/
 RUN dotnet publish WebApi/WebApi.csproj -c Release -o /app/publish
 
 FROM mcr.microsoft.com/dotnet/aspnet:9.0-alpine
-RUN apk add --no-cache icu-libs
+RUN apk add --no-cache icu-libs tzdata
 ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false
 WORKDIR /app
 COPY --from=build /app/publish .


### PR DESCRIPTION
## Summary
- Adds `tzdata` to the `apk add` in `WebApi/Dockerfile` so `TimeZoneInfo.FindSystemTimeZoneById("America/Chicago")` resolves correctly at runtime on Alpine

## Test plan
- [ ] Build the webapi image and verify the admin page loads without `TimeZoneNotFoundException`