### PR TITLE
Fix nginx caching stale webapi IP after container restart

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -3,8 +3,11 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    resolver 127.0.0.11 valid=30s;
+
     location /api/ {
-        proxy_pass http://webapi:8080/api/;
+        set $upstream webapi;
+        proxy_pass http://$upstream:8080/api/;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
     }


### PR DESCRIPTION
Use Docker's embedded DNS resolver (127.0.0.11) with a variable upstream so nginx re-resolves the webapi hostname dynamically instead of caching the IP at startup.

https://claude.ai/code/session_016EheqTXKSmZehYMh5ieKMo