### PR TITLE
Fix nginx proxy_pass double-path 404 on API routes

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -7,7 +7,7 @@ server {
 
     location /api/ {
         set $upstream webapi;
-        proxy_pass http://$upstream:8080/api/;
+        proxy_pass http://$upstream:8080;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
     }


### PR DESCRIPTION
## Summary

- When `proxy_pass` uses a variable (`$upstream`), nginx skips its normal URI rewriting, causing requests to be forwarded with a double `/api/` prefix (e.g. `/api//api/Admin/GetHealthChecks`) that ASP.NET Core can't match → 404
- Fixed by removing the `/api/` path from `proxy_pass`, using `http://$upstream:8080` instead — nginx then passes the original request URI unchanged, which already contains `/api/`

## Test plan

- [ ] Deploy updated frontend container
- [ ] Verify `/api/Admin/GetHealthChecks` returns 200
- [ ] Verify `/api/Admin/GetJobStatuses` returns 200
- [ ] Verify main game odds page still loads correctly

https://claude.ai/code/session_016EheqTXKSmZehYMh5ieKMo