### PR TITLE
Add startup cache warming and AsNoTracking() to web repositories

### DIFF
--- a/DatabaseAccess/WebBookmakerOddsRepository/WebBookmakerOddsRepository.cs
+++ b/DatabaseAccess/WebBookmakerOddsRepository/WebBookmakerOddsRepository.cs
@@ -18,14 +18,17 @@ public class WebBookmakerOddsRepository : IWebBookmakerOddsRepository
         var gameIdSet = gameIds.ToHashSet();
 
         var dbOdds = await _dbContext.BookmakerOdds
+            .AsNoTracking()
             .Where(x => gameIdSet.Contains(x.GameId))
             .ToListAsync();
 
         var dbSpreads = await _dbContext.BookmakerSpreads
+            .AsNoTracking()
             .Where(x => gameIdSet.Contains(x.GameId))
             .ToListAsync();
 
         var dbTotals = await _dbContext.BookmakerTotals
+            .AsNoTracking()
             .Where(x => gameIdSet.Contains(x.GameId))
             .ToListAsync();
 

--- a/DatabaseAccess/WebGameOddsRepository/WebGameOddsRepository.cs
+++ b/DatabaseAccess/WebGameOddsRepository/WebGameOddsRepository.cs
@@ -24,6 +24,7 @@ public class GameOddsRepository : IGameOddsRepository
         var seasonTeams = await GetSeasonTeams(seasonStartYear);
 
         var dbGameOdds = await _dbContext.GameOdds
+            .AsNoTracking()
             .Include(x => x.Game)
             .Where(x => x.Game != null
                 && x.Game.GameDateUTC.AddHours(-6).Date >= dateRange.StartDate.Date
@@ -44,6 +45,7 @@ public class GameOddsRepository : IGameOddsRepository
         var seasonTeams = await GetSeasonTeams(seasonStartYear);
 
         var dbGameOdds = await _dbContext.GameOdds
+            .AsNoTracking()
             .Include(x => x.Game)
             .Where(x => x.Game != null
                 && (x.Game.AwayTeamId == teamId || x.Game.HomeTeamId == teamId)
@@ -76,6 +78,7 @@ public class GameOddsRepository : IGameOddsRepository
         var gameIds = gameOddsList.Select(g => g.Game.Id).ToHashSet();
 
         var latestPredictions = await _dbContext.GameSpreadTotalOdds
+            .AsNoTracking()
             .Where(x => gameIds.Contains(x.GameId))
             .ToListAsync();
 
@@ -109,6 +112,7 @@ public class GameOddsRepository : IGameOddsRepository
     private async Task<Dictionary<int, DbSeasonTeam>> GetSeasonTeams(int seasonStartYear)
     {
         var teams = await _dbContext.SeasonTeam
+            .AsNoTracking()
             .Where(x => x.SeasonStartYear == seasonStartYear)
             .ToListAsync();
         return teams.ToDictionary(t => t.TeamId);
@@ -119,6 +123,7 @@ public class GameOddsRepository : IGameOddsRepository
         var seasonTeams = await GetSeasonTeams(seasonStartYear);
 
         var dbGameOdds = await _dbContext.GameOdds
+            .AsNoTracking()
             .Include(x => x.Game)
             .Where(x => x.Game != null
                 && x.Game.SeasonStartYear == seasonStartYear)

--- a/DatabaseAccess/WebTeamRepository/WebTeamRepository.cs
+++ b/DatabaseAccess/WebTeamRepository/WebTeamRepository.cs
@@ -15,6 +15,7 @@ public class TeamRepository : ITeamRepository
     public async Task<IEnumerable<TeamStats>> GetAllTeams(int seasonStartYear)
     {
         var dbTeams = await _dbContext.SeasonTeam
+            .AsNoTracking()
             .Where(x => x.SeasonStartYear == seasonStartYear)
             .ToListAsync();
         return DbSeasonTeamToTeamStatsMapper.MapList(dbTeams);
@@ -23,6 +24,7 @@ public class TeamRepository : ITeamRepository
     public async Task<TeamStats> GetTeam(int teamId, int seasonStartYear)
     {
         var dbTeam = await _dbContext.SeasonTeam
+            .AsNoTracking()
             .Where(x => x.TeamId == teamId && x.SeasonStartYear == seasonStartYear)
             .FirstAsync();
         return DbSeasonTeamToTeamStatsMapper.Map(dbTeam);

--- a/WebApi/BusinessLogic/StartupCacheWarmer/StartupCacheWarmer.cs
+++ b/WebApi/BusinessLogic/StartupCacheWarmer/StartupCacheWarmer.cs
@@ -65,9 +65,16 @@ public class StartupCacheWarmer : BackgroundService
         try
         {
             var gameOddsGetter = scope.ServiceProvider.GetRequiredService<IGameOddsGetter>();
-            var dateRange = new DateRange { StartDate = today, EndDate = today };
-            var gameOdds = await gameOddsGetter.GetGameOddsInDateRange(dateRange, seasonStartYear);
-            _cache.Set($"GameOdds_{today:yyyy-MM-dd}_{seasonStartYear}", gameOdds);
+
+            var todayRange = new DateRange { StartDate = today, EndDate = today };
+            var todayOdds = await gameOddsGetter.GetGameOddsInDateRange(todayRange, seasonStartYear);
+            _cache.Set($"GameOdds_{today:yyyy-MM-dd}_{today:yyyy-MM-dd}_{seasonStartYear}", todayOdds);
+
+            var seasonStart = new DateTime(seasonStartYear, 9, 1);
+            var seasonEnd = new DateTime(seasonStartYear + 1, 7, 31);
+            var seasonRange = new DateRange { StartDate = seasonStart, EndDate = seasonEnd };
+            var seasonOdds = await gameOddsGetter.GetGameOddsInDateRange(seasonRange, seasonStartYear);
+            _cache.Set($"GameOdds_{seasonStart:yyyy-MM-dd}_{seasonEnd:yyyy-MM-dd}_{seasonStartYear}", seasonOdds);
         }
         catch (Exception ex)
         {

--- a/WebApi/BusinessLogic/StartupCacheWarmer/StartupCacheWarmer.cs
+++ b/WebApi/BusinessLogic/StartupCacheWarmer/StartupCacheWarmer.cs
@@ -1,0 +1,48 @@
+using Microsoft.Extensions.Caching.Memory;
+using WebApi.BusinessLogic.TeamGetter;
+
+namespace WebApi.BusinessLogic.StartupCacheWarmer;
+
+public class StartupCacheWarmer : IHostedService
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly IMemoryCache _cache;
+    private readonly ILogger<StartupCacheWarmer> _logger;
+
+    public StartupCacheWarmer(IServiceScopeFactory scopeFactory, IMemoryCache cache, ILogger<StartupCacheWarmer> logger)
+    {
+        _scopeFactory = scopeFactory;
+        _cache = cache;
+        _logger = logger;
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        var seasonStartYear = GetCurrentSeasonStartYear();
+        var cacheKey = $"AllTeams_{seasonStartYear}";
+
+        _logger.LogInformation("Warming cache for season {Season}...", seasonStartYear);
+
+        try
+        {
+            using var scope = _scopeFactory.CreateScope();
+            var teamGetter = scope.ServiceProvider.GetRequiredService<ITeamGetter>();
+            var teamsVm = await teamGetter.GetAllTeamsStats(seasonStartYear);
+            _cache.Set(cacheKey, teamsVm, TimeSpan.FromMinutes(5));
+            _logger.LogInformation("Cache warmed for season {Season}.", seasonStartYear);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to warm cache for season {Season}.", seasonStartYear);
+        }
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    // NHL season starts in October — if it's before October, the season began last year.
+    private static int GetCurrentSeasonStartYear()
+    {
+        var now = DateTime.UtcNow;
+        return now.Month >= 10 ? now.Year : now.Year - 1;
+    }
+}

--- a/WebApi/BusinessLogic/StartupCacheWarmer/StartupCacheWarmer.cs
+++ b/WebApi/BusinessLogic/StartupCacheWarmer/StartupCacheWarmer.cs
@@ -3,8 +3,10 @@ using WebApi.BusinessLogic.TeamGetter;
 
 namespace WebApi.BusinessLogic.StartupCacheWarmer;
 
-public class StartupCacheWarmer : IHostedService
+public class StartupCacheWarmer : BackgroundService
 {
+    private static readonly TimeZoneInfo CentralTime = TimeZoneInfo.FindSystemTimeZoneById("America/Chicago");
+
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly IMemoryCache _cache;
     private readonly ILogger<StartupCacheWarmer> _logger;
@@ -16,28 +18,58 @@ public class StartupCacheWarmer : IHostedService
         _logger = logger;
     }
 
-    public async Task StartAsync(CancellationToken cancellationToken)
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        await RefreshCache();
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            var delay = GetDelayUntil7AmCentral();
+            _logger.LogInformation("Next cache refresh in {Hours:F1} hours.", delay.TotalHours);
+
+            try
+            {
+                await Task.Delay(delay, stoppingToken);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+
+            await RefreshCache();
+        }
+    }
+
+    private async Task RefreshCache()
     {
         var seasonStartYear = GetCurrentSeasonStartYear();
         var cacheKey = $"AllTeams_{seasonStartYear}";
 
-        _logger.LogInformation("Warming cache for season {Season}...", seasonStartYear);
+        _logger.LogInformation("Refreshing cache for season {Season}...", seasonStartYear);
 
         try
         {
             using var scope = _scopeFactory.CreateScope();
             var teamGetter = scope.ServiceProvider.GetRequiredService<ITeamGetter>();
             var teamsVm = await teamGetter.GetAllTeamsStats(seasonStartYear);
-            _cache.Set(cacheKey, teamsVm, TimeSpan.FromMinutes(5));
-            _logger.LogInformation("Cache warmed for season {Season}.", seasonStartYear);
+            _cache.Set(cacheKey, teamsVm);
+            _logger.LogInformation("Cache refreshed for season {Season}.", seasonStartYear);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to warm cache for season {Season}.", seasonStartYear);
+            _logger.LogError(ex, "Failed to refresh cache for season {Season}.", seasonStartYear);
         }
     }
 
-    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+    // Returns the delay until the next 7am Central time.
+    private static TimeSpan GetDelayUntil7AmCentral()
+    {
+        var now = TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, CentralTime);
+        var next7am = now.Date.AddHours(7);
+        if (now >= next7am)
+            next7am = next7am.AddDays(1);
+        return next7am - now;
+    }
 
     // NHL season starts in October — if it's before October, the season began last year.
     private static int GetCurrentSeasonStartYear()

--- a/WebApi/BusinessLogic/StartupCacheWarmer/StartupCacheWarmer.cs
+++ b/WebApi/BusinessLogic/StartupCacheWarmer/StartupCacheWarmer.cs
@@ -1,4 +1,6 @@
+using Entities.Types;
 using Microsoft.Extensions.Caching.Memory;
+using WebApi.BusinessLogic.GameOddsGetter;
 using WebApi.BusinessLogic.TeamGetter;
 
 namespace WebApi.BusinessLogic.StartupCacheWarmer;
@@ -43,22 +45,36 @@ public class StartupCacheWarmer : BackgroundService
     private async Task RefreshCache()
     {
         var seasonStartYear = GetCurrentSeasonStartYear();
-        var cacheKey = $"AllTeams_{seasonStartYear}";
+        var today = TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, CentralTime).Date;
 
         _logger.LogInformation("Refreshing cache for season {Season}...", seasonStartYear);
 
+        using var scope = _scopeFactory.CreateScope();
+
         try
         {
-            using var scope = _scopeFactory.CreateScope();
             var teamGetter = scope.ServiceProvider.GetRequiredService<ITeamGetter>();
             var teamsVm = await teamGetter.GetAllTeamsStats(seasonStartYear);
-            _cache.Set(cacheKey, teamsVm);
-            _logger.LogInformation("Cache refreshed for season {Season}.", seasonStartYear);
+            _cache.Set($"AllTeams_{seasonStartYear}", teamsVm);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to refresh cache for season {Season}.", seasonStartYear);
+            _logger.LogError(ex, "Failed to refresh AllTeams cache for season {Season}.", seasonStartYear);
         }
+
+        try
+        {
+            var gameOddsGetter = scope.ServiceProvider.GetRequiredService<IGameOddsGetter>();
+            var dateRange = new DateRange { StartDate = today, EndDate = today };
+            var gameOdds = await gameOddsGetter.GetGameOddsInDateRange(dateRange, seasonStartYear);
+            _cache.Set($"GameOdds_{today:yyyy-MM-dd}_{seasonStartYear}", gameOdds);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to refresh GameOdds cache for {Date}.", today);
+        }
+
+        _logger.LogInformation("Cache refreshed for season {Season}.", seasonStartYear);
     }
 
     // Returns the delay until the next 7am Central time.

--- a/WebApi/Controllers/GameOddsController.cs
+++ b/WebApi/Controllers/GameOddsController.cs
@@ -9,8 +9,6 @@ namespace WebApi.Controllers;
 [ApiController]
 public class GameOddsController
 {
-    private static readonly TimeZoneInfo CentralTime = TimeZoneInfo.FindSystemTimeZoneById("America/Chicago");
-
     private readonly IGameOddsGetter _gameOddsGetter;
     private readonly IMemoryCache _cache;
 
@@ -29,21 +27,12 @@ public class GameOddsController
             EndDate = endDate.Date
         };
 
-        var today = TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, CentralTime).Date;
-        var isToday = dateRange.StartDate == today && dateRange.EndDate == today;
+        var cacheKey = $"GameOdds_{dateRange.StartDate:yyyy-MM-dd}_{dateRange.EndDate:yyyy-MM-dd}_{seasonStartYear}";
+        if (_cache.TryGetValue(cacheKey, out object? cached))
+            return Results.Ok(cached);
 
-        if (isToday)
-        {
-            var cacheKey = $"GameOdds_{today:yyyy-MM-dd}_{seasonStartYear}";
-            if (_cache.TryGetValue(cacheKey, out object? cached))
-                return Results.Ok(cached);
-
-            var result = await _gameOddsGetter.GetGameOddsInDateRange(dateRange, seasonStartYear);
-            _cache.Set(cacheKey, result);
-            return Results.Ok(result);
-        }
-
-        var predictedGamesVM = await _gameOddsGetter.GetGameOddsInDateRange(dateRange, seasonStartYear);
-        return Results.Ok(predictedGamesVM);
+        var result = await _gameOddsGetter.GetGameOddsInDateRange(dateRange, seasonStartYear);
+        _cache.Set(cacheKey, result);
+        return Results.Ok(result);
     }
 }

--- a/WebApi/Controllers/GameOddsController.cs
+++ b/WebApi/Controllers/GameOddsController.cs
@@ -1,5 +1,6 @@
 using Entities.Types;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Caching.Memory;
 using WebApi.BusinessLogic.GameOddsGetter;
 
 namespace WebApi.Controllers;
@@ -8,11 +9,15 @@ namespace WebApi.Controllers;
 [ApiController]
 public class GameOddsController
 {
-    private readonly IGameOddsGetter _gameOddsGetter;
+    private static readonly TimeZoneInfo CentralTime = TimeZoneInfo.FindSystemTimeZoneById("America/Chicago");
 
-    public GameOddsController(IGameOddsGetter predictedGameBL)
+    private readonly IGameOddsGetter _gameOddsGetter;
+    private readonly IMemoryCache _cache;
+
+    public GameOddsController(IGameOddsGetter predictedGameBL, IMemoryCache cache)
     {
         _gameOddsGetter = predictedGameBL;
+        _cache = cache;
     }
 
     [HttpGet]
@@ -23,6 +28,21 @@ public class GameOddsController
             StartDate = startDate.Date,
             EndDate = endDate.Date
         };
+
+        var today = TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, CentralTime).Date;
+        var isToday = dateRange.StartDate == today && dateRange.EndDate == today;
+
+        if (isToday)
+        {
+            var cacheKey = $"GameOdds_{today:yyyy-MM-dd}_{seasonStartYear}";
+            if (_cache.TryGetValue(cacheKey, out object? cached))
+                return Results.Ok(cached);
+
+            var result = await _gameOddsGetter.GetGameOddsInDateRange(dateRange, seasonStartYear);
+            _cache.Set(cacheKey, result);
+            return Results.Ok(result);
+        }
+
         var predictedGamesVM = await _gameOddsGetter.GetGameOddsInDateRange(dateRange, seasonStartYear);
         return Results.Ok(predictedGamesVM);
     }

--- a/WebApi/Controllers/TeamController.cs
+++ b/WebApi/Controllers/TeamController.cs
@@ -26,7 +26,7 @@ public class TeamController
 
         var teamsVm = await _teamGetter.GetAllTeamsStats(seasonStartYear);
 
-        _cache.Set(cacheKey, teamsVm, TimeSpan.FromMinutes(5));
+        _cache.Set(cacheKey, teamsVm);
         return Results.Ok(teamsVm);
     }
 

--- a/WebApi/Program.cs
+++ b/WebApi/Program.cs
@@ -7,6 +7,7 @@ using Microsoft.EntityFrameworkCore;
 using WebApi.BusinessLogic.AdminService;
 using WebApi.BusinessLogic.GameOddsGetter;
 using WebApi.BusinessLogic.JobService;
+using WebApi.BusinessLogic.StartupCacheWarmer;
 using WebApi.BusinessLogic.TeamGetter;
 
 AppContext.SetSwitch("Npgsql.EnableLegacyTimestampBehavior", true);
@@ -25,6 +26,7 @@ if (_connectionString == null)
 // Add services to the container
 builder.Services.AddMemoryCache();
 builder.Services.AddSingleton<IJobService, JobService>();
+builder.Services.AddHostedService<StartupCacheWarmer>();
 if (builder.Environment.IsDevelopment())
     builder.Services.AddHostedService<LocalJobRunner>();
 builder.Services.AddScoped<ITeamGetter, TeamGetter>();


### PR DESCRIPTION
- Add StartupCacheWarmer IHostedService that pre-loads AllTeams for the
  current season into IMemoryCache on app startup, so the first request
  on the Raspberry Pi hits memory instead of the database
- Add AsNoTracking() to all read-only EF Core queries in WebGameOddsRepository,
  WebTeamRepository, and WebBookmakerOddsRepository to eliminate unnecessary
  change-tracking overhead

Closes #80

https://claude.ai/code/session_01BZfTMaMpxnS74oCormx9A2