### PR TITLE
Add CSP header and no-inline-styles ESLint rule

### DIFF
--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -63,6 +63,9 @@ jobs:
       - name: Check formatting
         run: npm run format:check
 
+      - name: Lint
+        run: npm run lint
+
   python:
     name: Python Format
     runs-on: ubuntu-latest

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -2,6 +2,7 @@ import js from '@eslint/js'
 import globals from 'globals'
 import reactHooks from 'eslint-plugin-react-hooks'
 import reactRefresh from 'eslint-plugin-react-refresh'
+import react from 'eslint-plugin-react'
 import tseslint from 'typescript-eslint'
 import { defineConfig, globalIgnores } from 'eslint/config'
 
@@ -15,9 +16,21 @@ export default defineConfig([
       reactHooks.configs.flat.recommended,
       reactRefresh.configs.vite,
     ],
+    plugins: {
+      react,
+    },
     languageOptions: {
       ecmaVersion: 2020,
       globals: globals.browser,
+    },
+    settings: {
+      react: {
+        version: 'detect',
+      },
+    },
+    rules: {
+      'react/forbid-dom-props': ['error', { forbid: ['style'] }],
+      'react/forbid-component-props': ['error', { forbid: ['style'] }],
     },
   },
 ])

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -5,6 +5,8 @@ server {
 
     resolver 127.0.0.11 valid=30s;
 
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self';" always;
+
     location /api/ {
         set $upstream webapi;
         proxy_pass http://$upstream:8080;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,6 +28,7 @@
     "@types/serviceworker": "^0.0.193",
     "@vitejs/plugin-react": "^5.1.1",
     "eslint": "^9.39.1",
+    "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",
     "globals": "^16.5.0",

--- a/frontend/public/chevron-down.svg
+++ b/frontend/public/chevron-down.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="#737373" stroke-width="2">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7"/>
+</svg>

--- a/frontend/src/components/LogLossChart.tsx
+++ b/frontend/src/components/LogLossChart.tsx
@@ -3,6 +3,7 @@ import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'rec
 import { formatShortDate } from '../utils/dates';
 import { calculateLogLoss } from '../utils/predictions';
 import type { GameOddsVM } from '../types';
+import { getButtonClasses, getTextClass } from '../utils/colorClass';
 
 const HOMEGROWN = 'In-House Model';
 
@@ -133,12 +134,7 @@ export function LogLossChart({ games, deduplicateById }: Props) {
             <button
               key={name}
               onClick={() => toggle(name)}
-              className="px-2.5 py-1 rounded-full text-xs font-mono font-medium transition-all"
-              style={{
-                backgroundColor: active ? color + '22' : 'transparent',
-                color: active ? color : '#737373',
-                border: `1px solid ${active ? color + '66' : '#525252'}`,
-              }}
+              className={`px-2.5 py-1 rounded-full text-xs font-mono font-medium transition-all ${getButtonClasses(color, active)}`}
             >
               {name}
             </button>
@@ -167,23 +163,12 @@ export function LogLossChart({ games, deduplicateById }: Props) {
               if (!active || !payload?.length) return null;
               const d = payload[0].payload as Record<string, unknown>;
               return (
-                <div
-                  style={{
-                    backgroundColor: 'rgba(10, 10, 10, 0.9)',
-                    border: '1px solid rgba(255,255,255,0.08)',
-                    borderRadius: '8px',
-                    fontFamily: 'JetBrains Mono',
-                    fontSize: '12px',
-                    color: '#fff',
-                    backdropFilter: 'blur(12px)',
-                    padding: '8px 12px',
-                  }}
-                >
+                <div className="bg-[rgba(10,10,10,0.9)] border border-white/8 rounded-lg font-mono text-xs text-white backdrop-blur-md py-2 px-3">
                   <div>{label}</div>
                   {allChips
                     .filter((name) => enabled.has(name) && d[name] != null)
                     .map((name) => (
-                      <div key={name} style={{ color: getColor(name, allChips.indexOf(name)) }}>
+                      <div key={name} className={getTextClass(getColor(name, allChips.indexOf(name)))}>
                         {name}: {d[name] as number}
                       </div>
                     ))}

--- a/frontend/src/components/SeasonSelector.tsx
+++ b/frontend/src/components/SeasonSelector.tsx
@@ -12,11 +12,7 @@ export function SeasonSelector({ value, onChange }: SeasonSelectorProps) {
     <select
       value={value}
       onChange={(e) => onChange(Number(e.target.value))}
-      className="px-3 py-2 rounded-lg glass text-sm font-mono font-medium cursor-pointer appearance-none bg-[length:16px] bg-[right_8px_center] bg-no-repeat"
-      style={{
-        backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='%23737373' stroke-width='2'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' d='M19 9l-7 7-7-7'/%3E%3C/svg%3E")`,
-        paddingRight: '2rem',
-      }}
+      className="pl-3 pr-8 py-2 rounded-lg glass text-sm font-mono font-medium cursor-pointer appearance-none bg-[url('/chevron-down.svg')] bg-[length:16px] bg-[right_8px_center] bg-no-repeat"
     >
       {options.map((y) => (
         <option key={y} value={y}>

--- a/frontend/src/components/StrategyChart.tsx
+++ b/frontend/src/components/StrategyChart.tsx
@@ -10,6 +10,7 @@ import {
 } from 'recharts';
 import { formatShortDate } from '../utils/dates';
 import type { StrategyResult } from '../utils/bettingStrategies';
+import { getButtonClasses, getTextClass } from '../utils/colorClass';
 
 const STRATEGY_COLORS: Record<string, string> = {
   'In-House Winner': '#3b82f6',
@@ -84,12 +85,7 @@ export function StrategyChart({ results }: Props) {
             <button
               key={name}
               onClick={() => toggle(name)}
-              className="px-2.5 py-1 rounded-full text-xs font-mono font-medium transition-all"
-              style={{
-                backgroundColor: active ? color + '22' : 'transparent',
-                color: active ? color : '#737373',
-                border: `1px solid ${active ? color + '66' : '#525252'}`,
-              }}
+              className={`px-2.5 py-1 rounded-full text-xs font-mono font-medium transition-all ${getButtonClasses(color, active)}`}
             >
               {name}
             </button>
@@ -119,23 +115,12 @@ export function StrategyChart({ results }: Props) {
               if (!active || !payload?.length) return null;
               const d = payload[0].payload as Record<string, unknown>;
               return (
-                <div
-                  style={{
-                    backgroundColor: 'rgba(10, 10, 10, 0.9)',
-                    border: '1px solid rgba(255,255,255,0.08)',
-                    borderRadius: '8px',
-                    fontFamily: 'JetBrains Mono',
-                    fontSize: '12px',
-                    color: '#fff',
-                    backdropFilter: 'blur(12px)',
-                    padding: '8px 12px',
-                  }}
-                >
+                <div className="bg-[rgba(10,10,10,0.9)] border border-white/8 rounded-lg font-mono text-xs text-white backdrop-blur-md py-2 px-3">
                   <div>{label}</div>
                   {strategyNames
                     .filter((name) => enabled.has(name) && d[name] != null)
                     .map((name) => (
-                      <div key={name} style={{ color: STRATEGY_COLORS[name] ?? '#737373' }}>
+                      <div key={name} className={getTextClass(STRATEGY_COLORS[name] ?? '#737373')}>
                         {name}: {(d[name] as number).toFixed(2)}u
                       </div>
                     ))}

--- a/frontend/src/components/StrategySummary.tsx
+++ b/frontend/src/components/StrategySummary.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react';
 import type { StrategyResult } from '../utils/bettingStrategies';
+import { getTextClass } from '../utils/colorClass';
 
 const STRATEGY_COLORS: Record<string, string> = {
   'In-House Winner': '#3b82f6',
@@ -23,7 +24,7 @@ export function StrategyCard({ result: r, children }: Props) {
   return (
     <div className="glass rounded-xl p-5">
       <div className="flex items-center justify-between mb-3">
-        <div className="text-xs font-semibold uppercase tracking-wider" style={{ color }}>
+        <div className={`text-xs font-semibold uppercase tracking-wider ${getTextClass(color)}`}>
           {r.name}
         </div>
         {children && <div className="flex flex-wrap gap-1">{children}</div>}

--- a/frontend/src/utils/colorClass.ts
+++ b/frontend/src/utils/colorClass.ts
@@ -1,0 +1,67 @@
+const BUTTON_ACTIVE: Record<string, string> = {
+  '#3b82f6': 'text-[#3b82f6] bg-[#3b82f622] border border-[#3b82f666]',
+  '#22c55e': 'text-[#22c55e] bg-[#22c55e22] border border-[#22c55e66]',
+  '#f97316': 'text-[#f97316] bg-[#f9731622] border border-[#f9731666]',
+  '#a855f7': 'text-[#a855f7] bg-[#a855f722] border border-[#a855f766]',
+  '#53d337': 'text-[#53d337] bg-[#53d33722] border border-[#53d33766]',
+  '#1493ff': 'text-[#1493ff] bg-[#1493ff22] border border-[#1493ff66]',
+  '#c4a44a': 'text-[#c4a44a] bg-[#c4a44a22] border border-[#c4a44a66]',
+  '#e53e3e': 'text-[#e53e3e] bg-[#e53e3e22] border border-[#e53e3e66]',
+  '#1e90ff': 'text-[#1e90ff] bg-[#1e90ff22] border border-[#1e90ff66]',
+  '#1b3668': 'text-[#1b3668] bg-[#1b366822] border border-[#1b366866]',
+  '#e44d2e': 'text-[#e44d2e] bg-[#e44d2e22] border border-[#e44d2e66]',
+  '#0a4d3c': 'text-[#0a4d3c] bg-[#0a4d3c22] border border-[#0a4d3c66]',
+  '#14805e': 'text-[#14805e] bg-[#14805e22] border border-[#14805e66]',
+  '#8b0000': 'text-[#8b0000] bg-[#8b000022] border border-[#8b000066]',
+  '#7c3aed': 'text-[#7c3aed] bg-[#7c3aed22] border border-[#7c3aed66]',
+  '#e879f9': 'text-[#e879f9] bg-[#e879f922] border border-[#e879f966]',
+  '#fb923c': 'text-[#fb923c] bg-[#fb923c22] border border-[#fb923c66]',
+  '#a78bfa': 'text-[#a78bfa] bg-[#a78bfa22] border border-[#a78bfa66]',
+  '#facc15': 'text-[#facc15] bg-[#facc1522] border border-[#facc1566]',
+  '#34d399': 'text-[#34d399] bg-[#34d39922] border border-[#34d39966]',
+  '#f87171': 'text-[#f87171] bg-[#f8717122] border border-[#f8717166]',
+  '#60a5fa': 'text-[#60a5fa] bg-[#60a5fa22] border border-[#60a5fa66]',
+  '#c084fc': 'text-[#c084fc] bg-[#c084fc22] border border-[#c084fc66]',
+  '#4ade80': 'text-[#4ade80] bg-[#4ade8022] border border-[#4ade8066]',
+  '#fbbf24': 'text-[#fbbf24] bg-[#fbbf2422] border border-[#fbbf2466]',
+};
+
+const BUTTON_INACTIVE = 'text-neutral-500 bg-transparent border border-neutral-600';
+
+const TEXT_CLASS: Record<string, string> = {
+  '#3b82f6': 'text-[#3b82f6]',
+  '#22c55e': 'text-[#22c55e]',
+  '#f97316': 'text-[#f97316]',
+  '#a855f7': 'text-[#a855f7]',
+  '#53d337': 'text-[#53d337]',
+  '#1493ff': 'text-[#1493ff]',
+  '#c4a44a': 'text-[#c4a44a]',
+  '#e53e3e': 'text-[#e53e3e]',
+  '#1e90ff': 'text-[#1e90ff]',
+  '#1b3668': 'text-[#1b3668]',
+  '#e44d2e': 'text-[#e44d2e]',
+  '#0a4d3c': 'text-[#0a4d3c]',
+  '#14805e': 'text-[#14805e]',
+  '#8b0000': 'text-[#8b0000]',
+  '#7c3aed': 'text-[#7c3aed]',
+  '#e879f9': 'text-[#e879f9]',
+  '#fb923c': 'text-[#fb923c]',
+  '#a78bfa': 'text-[#a78bfa]',
+  '#facc15': 'text-[#facc15]',
+  '#34d399': 'text-[#34d399]',
+  '#f87171': 'text-[#f87171]',
+  '#60a5fa': 'text-[#60a5fa]',
+  '#c084fc': 'text-[#c084fc]',
+  '#4ade80': 'text-[#4ade80]',
+  '#fbbf24': 'text-[#fbbf24]',
+  '#737373': 'text-neutral-500',
+};
+
+export function getButtonClasses(color: string, active: boolean): string {
+  if (!active) return BUTTON_INACTIVE;
+  return BUTTON_ACTIVE[color] ?? BUTTON_INACTIVE;
+}
+
+export function getTextClass(color: string): string {
+  return TEXT_CLASS[color] ?? 'text-neutral-500';
+}


### PR DESCRIPTION
Closes #95

## Summary
- Add `Content-Security-Policy` header to nginx config blocking inline styles (`style-src 'self'`)
- Add `eslint-plugin-react` with `react/forbid-dom-props` and `react/forbid-component-props` rules to enforce no `style` props
- Fix all 8 existing inline style violations in `SeasonSelector`, `StrategySummary`, `StrategyChart`, and `LogLossChart` using Tailwind classes and a `colorClass` utility for dynamic colors
- Add ESLint step to the `format-check` CI workflow (included under the existing Format Check badge)

## Test plan
- [ ] `npm run lint` passes with no errors in `frontend/`
- [ ] `npm run format:check` still passes
- [ ] App builds and runs; chart colors, tooltips, and season selector render correctly
- [ ] CSP header is present in nginx responses

---
_Generated by [Claude Code](https://claude.ai/code/session_018Pixg4RSy6SVMiSm6dx8vm)_