### PR TITLE
Fix Prettier formatting in LogLossChart.tsx

### DIFF
--- a/frontend/src/components/LogLossChart.tsx
+++ b/frontend/src/components/LogLossChart.tsx
@@ -168,7 +168,10 @@ export function LogLossChart({ games, deduplicateById }: Props) {
                   {allChips
                     .filter((name) => enabled.has(name) && d[name] != null)
                     .map((name) => (
-                      <div key={name} className={getTextClass(getColor(name, allChips.indexOf(name)))}>
+                      <div
+                        key={name}
+                        className={getTextClass(getColor(name, allChips.indexOf(name)))}
+                      >
                         {name}: {d[name] as number}
                       </div>
                     ))}


### PR DESCRIPTION
Runs `prettier --write` on LogLossChart.tsx to fix the formatting issue that broke the Frontend Format CI job.

---
_Generated by [Claude Code](https://claude.ai/code/session_018Pixg4RSy6SVMiSm6dx8vm)_